### PR TITLE
Correção na pesquisa dos termos.

### DIFF
--- a/src/main/java/gui/Grid.java
+++ b/src/main/java/gui/Grid.java
@@ -156,6 +156,7 @@ public class Grid extends JScrollPane {
 				escaped = escaped.replace( "*", "\\*" );
 				escaped = escaped.replace( "{", "\\{" );
 				escaped = escaped.replace( "(", "\\(" );
+				escaped = escaped.replace( ")", "\\)" );
 				escaped = escaped.replace( "|", "\\|" );
 				
 				// Qualquer letra


### PR DESCRIPTION
Corrigido o erro em pesquisas que utilizavam o caractere ")". #17 
